### PR TITLE
Fix arbitrary target example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ run as root it installs it into `/usr/local/bin`.
 To install `ubi` into an arbitrary location, set the `$TARGET` env var:
 
 ```
-TARGET=~/local/bin curl --silent --location \
+curl --silent --location \
     https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
-    sh
+    TARGET=~/local/bin sh
 ```
 
 If the `GITHUB_TOKEN` env var is set, then the bootstrap script will use this


### PR DESCRIPTION
My apologies. I tested that the var was being set in the script and I just assumed that the env var would propagate as expected for the installer example. It turns out that order matters. :)