### PR TITLE
DWIM uncompressing *.xz binaries

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,9 @@
 * Handle bare xz-compressed binaries. Previously ubi would download and
   "install" the compressed file as an executable. Now ubi will uncompress this
   file properly. Based on PR #19 from Marco Fontani.
+* Fixed a bug in handling of xz-compressed tarballs. There was some support
+  for this, but it wasn't complete. These should now be handled just like
+  other compressed tarballs.
 
 
 ## 0.0.11 - 2022-07-03

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+## 0.0.12
+
+* Handle bare xz-compressed binaries. Previously ubi would download and
+  "install" the compressed file as an executable. Now ubi will uncompress this
+  file properly. Based on PR #19 from Marco Fontani.
+
+
 ## 0.0.11 - 2022-07-03
 
 * Improved handling of urls passed to `--project` so any path that contains an

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,12 +194,13 @@ impl Ubi {
             base.join(project)?
         };
         let parts = url.path().split('/').collect::<Vec<_>>();
-        if parts.len() < 3 {
+        if parts.len() < 3 || parts[1].is_empty() || parts[2].is_empty() {
             return Err(anyhow!(
                 "could not parse org and repo name from --project: {}",
-                url
+                project,
             ));
         }
+
         // The first part is an empty string for the leading '/' in the path.
         let (org, proj) = (parts[1], parts[2]);
         debug!("Parsed project {} = {} / {}", project, org, proj);

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,10 +517,12 @@ impl Ubi {
                 )
             })
             .to_string_lossy();
-        if filename.ends_with(".tar.gz")
-            || filename.ends_with(".tgz")
-            || filename.ends_with(".tar.bz")
+        if filename.ends_with(".tar.bz")
             || filename.ends_with(".tbz")
+            || filename.ends_with(".tar.gz")
+            || filename.ends_with(".tgz")
+            || filename.ends_with(".tar.xz")
+            || filename.ends_with(".txz")
         {
             self.extract_tarball(downloaded_file)
         } else if filename.ends_with(".zip") {

--- a/tests/ubi.rs
+++ b/tests/ubi.rs
@@ -121,6 +121,29 @@ fn tests() -> Result<()> {
         }
     }
 
+    // This project only has a Linux release. It has a single `.xz` file in
+    // its releases which uncompresses to an ELF binary.
+    #[cfg(target_os = "linux")]
+    {
+        let prettycrontab_bin = make_pathbuf(&["bin", "prettycrontab"]);
+        let _td = run_test(
+            ubi.as_ref(),
+            &["--project", "mfontani/prettycrontab", "--tag", "v0.0.2"],
+            prettycrontab_bin.clone(),
+        )?;
+        match run_command(prettycrontab_bin.as_ref(), &["-version"]) {
+            Ok((code, stdout, _)) => {
+                assert!(code == 0, "exit code is 0");
+                assert!(stdout.is_some(), "got stdout from prettycrontab");
+                assert!(
+                    stdout.unwrap().contains("v0.0.2"),
+                    "got the expected stdout",
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
     #[cfg(target_os = "linux")]
     {
         let delta_bin = make_pathbuf(&["bin", "delta"]);


### PR DESCRIPTION
My own projects provide a Xz-compressed binary. ubi downloads them fine,
but doesn't uncompress them. It DWIMs removal of the ".xz" suffix, but
that's it:

    $ ./ubi --project mfontani/prettycrontab --in . ; file ./prettycrontab
    ./prettycrontab: XZ compressed data

With this patch, it DWIMs the uncompress step (same as binaries with
`.gz` suffix) and DWIMs properly:

    $ ./target/debug/ubi --project mfontani/prettycrontab --in ./ ; file prettycrontab
    prettycrontab: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=xE0vnpwb2k79P9DJEF_x/XP_ueft0E21ugRnpFQi6/pPHhPi1sBgkPO24gj2XM/Ob3l7my2Ldm3xGYS0RhD, stripped