### PR TITLE
Fix binary ending in xz

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -461,7 +461,7 @@ impl Ubi {
         let mut names: Vec<String> = vec![];
 
         let valid_extensions: &'static [&'static str] = &[
-            ".tar.gz", ".tgz", ".tar.bz", ".tbz", ".tar.xz", ".txz", ".zip", ".gz",
+            ".tar.gz", ".tgz", ".tar.bz", ".tbz", ".tar.xz", ".txz", ".zip", ".gz", ".xz",
         ];
 
         // This could all be done much more simply with the iterator's .find()

--- a/tests/ubi.rs
+++ b/tests/ubi.rs
@@ -218,6 +218,28 @@ fn tests() -> Result<()> {
         }
     }
 
+    // This project has multiple releases, which are binaries.
+    // The darwin and linux executables are xz'ed.
+    #[cfg(target_os = "linux")]
+    {
+        let tstdin_bin = make_exe_pathbuf(&["bin", "tstdin"]);
+        let _td = run_test(
+            ubi.as_ref(),
+            &["--project", "mfontani/tstdin", "--tag", "v0.2.3"],
+            tstdin_bin.clone(),
+        )?;
+        match run_command(tstdin_bin.as_ref(), &["-version"]) {
+            Ok((stdout, _)) => {
+                assert!(stdout.is_some(), "got stdout from tstdin");
+                assert!(
+                    stdout.unwrap().contains("v0.2.3"),
+                    "got the expected stdout",
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
     #[cfg(target_os = "linux")]
     {
         let delta_bin = make_exe_pathbuf(&["bin", "delta"]);


### PR DESCRIPTION
I previously submitted a patch for making `.xz` DWIM, but it wasn't enough.

On another project, I added a list of multi-arch binaries which are then xz'ed, but ubi didn't work:

```bash
$ cargo run -- --project mfontani/tstdin --tag v0.2.3
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/ubi --project mfontani/tstdin --tag v0.2.3`
[ubi][ERROR] could not find a release for this OS and architecture from tstdin-darwin-amd64.xz, tstdin-linux-amd64.xz, tstdin.exe
```

The os (linux) matches; the arch (amd64) matches; it "just" chokes on the ".xz" ending, which it can totally handle.

So I'm adding ".xz" to the list of extensions it does, indeed, support.

... and the actual problem is now a test case, too.