### PR TITLE
Make the macOS regex allow `macosx`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## 0.2.5
+
+- When looking for macOS assets, `ubi` will now match against `macosx` in asset names, not just
+  `macos` and `osx`. Implemented by @kattouf (Vasiliy Kattouf). GH #80.
+
 ## 0.2.4 - 2024-11-24
 
 - `ubi` will now look for just "mac" or "Mac" in a filename when running on macOS. Previously, `ubi`

--- a/ubi/src/os.rs
+++ b/ubi/src/os.rs
@@ -19,7 +19,7 @@ pub(crate) fn linux_re() -> &'static Lazy<Regex> {
 }
 
 pub(crate) fn macos_re() -> &'static Lazy<Regex> {
-    regex!(r"(?i:(?:\b|_)(?:darwin|mac(?:os)?|osx)(?:\b|_))")
+    regex!(r"(?i:(?:\b|_)(?:darwin|mac(?:osx?)?|osx)(?:\b|_))")
 }
 
 pub(crate) fn netbsd_re() -> &'static Lazy<Regex> {

--- a/ubi/src/picker.rs
+++ b/ubi/src/picker.rs
@@ -448,6 +448,13 @@ mod test {
     )]
     #[test_case(
         "aarch64-apple-darwin",
+        &["project-Linux-x86-64.tar.gz", "project-Macosx-x86-64.tar.gz"],
+        None,
+        1 ;
+        "aarch64-apple-darwin - pick asset with 'macosx' in the name"
+    )]
+    #[test_case(
+        "aarch64-apple-darwin",
         &["project-Macos-x86-64.tar.gz", "project-Macos-aarch64.tar.gz"],
         None,
         1 ;


### PR DESCRIPTION
When using build triple names for release assets, there is an issue with macOS assets because the OS name in Swift’s build triples is macosx instead of macos.

Sources for reference:
	•	[List of possible triples in Swift tests](https://github.com/swiftlang/swift-driver/blob/9139db464832a77ce7ba3d2949d6b2fdf9c130a8/Tests/SwiftDriverTests/TripleTests.swift#L24)
	•	[Article on building Swift executables using triples](https://swifttoolkit.dev/posts/building-swift-executables)
	•	[Example of assets named by triples](https://github.com/kattouf/Sake/releases)
