### PR TITLE
Look for first matching file which is a _file_ in zip archive.

### DIFF
--- a/ubi/src/installer.rs
+++ b/ubi/src/installer.rs
@@ -113,7 +113,7 @@ impl ExeInstaller {
         for i in 0..zip.len() {
             let mut zf = zip.by_index(i)?;
             let path = PathBuf::from(zf.name());
-            if path.ends_with(&self.exe) {
+            if zf.is_file() && path.ends_with(&self.exe) {
                 let mut buffer: Vec<u8> = Vec::with_capacity(usize::try_from(zf.size())?);
                 zf.read_to_end(&mut buffer)?;
                 self.create_install_dir()?;


### PR DESCRIPTION
It is possible that the requested path in the zip can be found as a file, in addition to directory/symlink. The outcome if we don't filter by file type is confusing for the user, as the install can appear to succeed, but the result is an empty file.

Fixes: #88 