### PR TITLE
fix: allow symlink as an executable

### DIFF
--- a/ubi/src/installer.rs
+++ b/ubi/src/installer.rs
@@ -148,7 +148,8 @@ impl ExeInstaller {
         let mut possible_matches: Vec<usize> = vec![];
         for (i, entry) in arch.entries()?.enumerate() {
             let entry = entry?;
-            if !entry.header().entry_type().is_file() {
+            let entry_type = entry.header().entry_type();
+            if !entry_type.is_file() && !entry_type.is_symlink() {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/houseabsolute/ubi/issues/124.

With this change, ubi can now correctly extract symlinks into the bin directory, but it still fails with `[ubi][ERROR] No such file or directory (os error 2)`.

I think this is because the extracted symlink is broken, as its target file is also not being extracted.
To fix this, we would also need to extract the files pointed to by the symlinks in the bin directory, but I'm not sure if this is an acceptable approach.

(I was also unsure how to print a stack trace for the error.)

For the options, both are fine for me.