### PR TITLE
feat: match artifacts with "arm" in package name on macOS ARM64

### DIFF
--- a/ubi/src/arch.rs
+++ b/ubi/src/arch.rs
@@ -5,6 +5,38 @@ use std::sync::LazyLock;
 
 // This is a special case to account for the fact that MacOS ARM systems can
 // also run x86-64 binaries.
+pub(crate) fn macos_aarch64_all_re() -> &'static Lazy<Regex> {
+    regex!(
+        r"(?ix)
+        (?:
+            \b
+            |
+            _
+        )
+        (?:
+            aarch_?64
+            |
+            arm_?64
+            |
+            arm
+            |
+            x86[_-]64
+            |
+            x64
+            |
+            amd64
+            |
+            all
+        )
+        (?:
+            \b
+            |
+            _
+        )
+        "
+    )
+}
+
 pub(crate) fn macos_aarch64_re() -> &'static Lazy<Regex> {
     regex!(
         r"(?ix)
@@ -18,13 +50,7 @@ pub(crate) fn macos_aarch64_re() -> &'static Lazy<Regex> {
             |
             arm_?64
             |
-            x86[_-]64
-            |
-            x64
-            |
-            amd64
-            |
-            all
+            arm
         )
         (?:
             \b

--- a/ubi/src/picker.rs
+++ b/ubi/src/picker.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::{
     arch::{
-        aarch64_re, arm_re, macos_aarch64_re, mips64_re, mips64le_re, mips_re, mipsle_re, ppc32_re,
+        aarch64_re, arm_re, macos_aarch64_all_re, macos_aarch64_re, mips64_re, mips64le_re, mips_re, mipsle_re, ppc32_re,
         ppc64_re, ppc64le_re, riscv64_re, s390x_re, sparc64_re, x86_32_re, x86_64_re,
         ALL_ARCHES_RE,
     },
@@ -269,7 +269,12 @@ impl<'a> AssetPicker<'a> {
             return Ok(matches.remove(0));
         }
 
-        let filtered = self.maybe_filter_for_64_bit_arch(matches);
+        let (filtered, asset) = self.maybe_pick_asset_for_macos_arm(matches);
+        if let Some(asset) = asset {
+            return Ok(asset);
+        }
+
+        let filtered = self.maybe_filter_for_64_bit_arch(filtered);
 
         let (mut filtered, asset) = self.maybe_filter_for_matching_string(filtered)?;
         if let Some(asset) = asset {
@@ -279,11 +284,6 @@ impl<'a> AssetPicker<'a> {
         if filtered.len() == 1 {
             debug!("only found one candidate asset after filtering");
             return Ok(filtered.remove(0));
-        }
-
-        let (filtered, asset) = self.maybe_pick_asset_for_macos_arm(filtered);
-        if let Some(asset) = asset {
-            return Ok(asset);
         }
 
         debug!(
@@ -365,7 +365,7 @@ impl<'a> AssetPicker<'a> {
             "found multiple candidate assets and running on macOS ARM, filtering for arm64 binaries in {asset_names:?}",
         );
 
-        let arch_matcher = aarch64_re();
+        let arch_matcher = macos_aarch64_re();
 
         if let Some(idx) = matches.iter().position(|a| arch_matcher.is_match(&a.name)) {
             debug!("found ARM binary named {}", matches[idx].name);
@@ -410,7 +410,7 @@ impl<'a> AssetPicker<'a> {
         debug!("current CPU architecture = {}", self.platform.target_arch);
 
         if self.running_on_macos_arm() {
-            return macos_aarch64_re();
+            return macos_aarch64_all_re();
         }
 
         match (self.platform.target_arch, self.platform.target_endian) {
@@ -544,6 +544,14 @@ mod test {
         None,
         1 ;
         "aarch64-apple-darwin - pick the aarch64 asset on macOS ARM"
+    )]
+    #[test_case(
+        "aarch64-apple-darwin",
+        &["project-Macos-x86-64.tar.gz", "project-Macos-arm.tar.gz"],
+        None,
+        None,
+        1 ;
+        "aarch64-apple-darwin - pick the arm asset on macOS ARM"
     )]
     #[test_case(
         "aarch64-apple-darwin",


### PR DESCRIPTION
This PR improves the asset selection logic for macOS Apple Silicon (ARM64) systems to better handle asset names that contain "arm" (without "64" suffix) such as ["dcm-macos-arm-release.zip"](https://github.com/CQLabs/homebrew-dcm/releases).

I only modified `macos_aarch64_re()` and didn't change `aarch64_re()` because there's a risk of incorrectly selecting 32-bit binaries on non-macOS ARM64 environments.
Since all ARM environments on macOS are 64-bit, I believe this change will work correctly.

Note: I have contributed to this repository in the past. I allow edits to this branch and commits.