### PR TITLE
Fix Github private repo asset downloads by preferring API URL

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 ## 0.8.2
 
+- Fixed a bug introduced in 0.8.0, which caused `ubi` to prefer the `browser_download_url` over the
+  `url` for a GitHub asset. When both are present, it will now use the `url` field. This is
+  important because when downloading assets from a private repo, the `url` will work with the
+  authentication headers that `ubi` sets. Fixed by @rnaveiras (Raúl Naveiras). GH #139.
 - Added more context to errors and made `ubi` display the full error context when it fails. This
   should help with debugging issues like #136.
 


### PR DESCRIPTION
Private GitHub repositories require downloading assets via the API endpoint (api.github.com/repos/.../releases/assets/ID) with proper authentication headers, rather than direct download URLs (github.com/.../releases/download/...) which only work for public repos.

Changed Asset deserialisation to prefer `url` (API endpoint) over `browser_download_url` because the API endpoint works for both public and private repositories when authentication is provided, while the browser download URL returns 404 for private repos.

The existing download_asset method already sets the correct headers (Accept: application/octet-stream and Authorisation) required for API endpoint downloads.

## How to reproduce the issue with github and curl

```
export GITHUB_TOKEN="ghp_your_token_here"
export PRIVATE_REPO="foo/bar"
```

Get the last release form the API

```
curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
     -H "Accept: application/vnd.github+json" \
     https://api.github.com/repos/${PRIVATE_REPO}/releases/latest | jq '.assets[0] | { name, url, browser_download_url }'
```

example output:

```json
{
  "name": "bar_Darwin_arm64.tar.gz",
  "url": "https://api.github.com/repos/foo/bar/releases/assets/299331819",
  "browser_download_url": "https://github.com/foo/bar/releases/download/v0.1.0/bar_Darwin_arm64.tar.gz"
}
```

Try the browser download URL on a private repo (failed)

```bash
# this will fail with 404 for private repositories
curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
     "https://github.com/foo/bar/releases/download/v0.1.0/bar_Darwin_arm64.tar.gz`
```

Returns not found - You can add the `-o /tmp/bar.tar.gz` , you will see only writes a test file that contains (not found)


- Try with URL 

```bash
# this works
$ curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
     -H "Accept: application/octet-stream" \
     -o /tmp/bar.tar.gz \
     https://api.github.com/repos/foo/bar/releases/assets/123456

$ ls -lh /tmp/bar.tar.gz
```

## How to reproduce the issue with ubi

```bash
$ echo ${GITHUB_TOKEN:0:12}
github_pat_1

$ ubi --version
ubi 0.8.1
$ ubi --project foo/bar --in /tmp/test
[ubi][ERROR] error requesting https://github.com/foo/ares/bar/download/v0.1.0/bar_Darwin_arm64.tar.gz: 404 Not Found
Not Found
```

I can attached the debug output if necessary. I had changed the name of the repo for privacy, so foo/bar is not real, but you can test that with a private repo. 

