### PR TITLE
Add a new `--min-age-days` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +248,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "cipher"
@@ -472,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -797,6 +824,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1172,6 +1223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,7 +1439,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1580,7 +1640,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1944,7 +2004,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,6 +2225,7 @@ dependencies = [
  "async-trait",
  "binstall-tar",
  "bzip2 0.6.1",
+ "chrono",
  "document-features",
  "env_logger",
  "fern",
@@ -2397,7 +2458,42 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2405,6 +2501,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { version = "1.0.100", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
 binstall-tar = { version = "0.4.42", default-features = false }
 bzip2 = { version = "0.6.1" }
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 document-features = { version = "0.2" }
 # Used in some test code which can't use test_log.
 env_logger = { version = "0.11.8", default-features = false }

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+## 0.9.0
+
+- Added a new `--min-age-days` flag that tells `ubi` to only consider releases at least that old.
+  This is useful for mitigating supply chain attacks, especially for projects that use GitHub's
+  immutable releases feature. GH #145.
+
 ## 0.8.4 2025-11-01
 
 - This is the same as 0.8.3, but I had to publish this with a new tag because of a failed experiment

--- a/ubi/Cargo.toml
+++ b/ubi/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 binstall-tar.workspace = true
 bzip2.workspace = true
+chrono.workspace = true
 document-features.workspace = true
 fern = { workspace = true, optional = true }
 flate2.workspace = true

--- a/ubi/src/github.rs
+++ b/ubi/src/github.rs
@@ -1,9 +1,12 @@
-use crate::ubi::Asset;
 use anyhow::{anyhow, Result};
 use log::debug;
-use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 use url::Url;
+
+#[cfg(test)]
+use crate::ubi::Asset;
+#[cfg(test)]
+use serde::{Deserialize, Serialize};
 
 pub(crate) static PROJECT_BASE_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://github.com").unwrap());
@@ -11,9 +14,12 @@ pub(crate) static PROJECT_BASE_URL: LazyLock<Url> =
 pub(crate) static DEFAULT_API_BASE_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://api.github.com").unwrap());
 
+// Only used for test data serialization in forge.rs tests
+#[cfg(test)]
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct Release {
     pub(crate) assets: Vec<Asset>,
+    pub(crate) published_at: chrono::DateTime<chrono::Utc>,
 }
 
 pub(crate) fn parse_project_name_from_url(url: &Url, from: &str) -> Result<String> {

--- a/ubi/src/gitlab.rs
+++ b/ubi/src/gitlab.rs
@@ -1,9 +1,12 @@
-use crate::ubi::Asset;
 use anyhow::{anyhow, Result};
 use log::debug;
-use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 use url::Url;
+
+#[cfg(test)]
+use crate::ubi::Asset;
+#[cfg(test)]
+use serde::{Deserialize, Serialize};
 
 pub(crate) static PROJECT_BASE_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://gitlab.com").unwrap());
@@ -11,11 +14,15 @@ pub(crate) static PROJECT_BASE_URL: LazyLock<Url> =
 pub(crate) static DEFAULT_API_BASE_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://gitlab.com/api/v4").unwrap());
 
+// Only used for test data serialization in forge.rs tests
+#[cfg(test)]
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct Release {
     pub(crate) assets: Assets,
+    pub(crate) released_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[cfg(test)]
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct Assets {
     pub(crate) links: Vec<Asset>,


### PR DESCRIPTION
When set, `ubi` will only download a release that is at least X days old. This is useful for mitigating supply chain attacks, especially for projects that use GitHub's immutable releases feature.

This also includes some refactoring to better use serde. This eliminates the need for per-forge `Release` types.

This was mostly: 🤖 Generated with [Claude Code](https://claude.com/claude-code)